### PR TITLE
Fix link to discussions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Please [post an issue](https://github.com/envkey/envkey/issues) if you encounter
 
 ## Discussion and Community
 
-[Jump in](https://github.com/envkey/envkey/discussion) and ask a question, leave some feedback, ask for new features, or help out another EnvKey user.
+[Jump in](https://github.com/envkey/envkey/discussions) and ask a question, leave some feedback, ask for new features, or help out another EnvKey user.
 
 ## Support
 


### PR DESCRIPTION
Currently the link to the discussion page brings you to a 404 Not Found page. Also note that the "Discussion" link on the footer of the [website](https://www.envkey.com) has a similar issue (linking to `/discussion` instead of `/discussions`).